### PR TITLE
Fix nginx default config problem for debian(-derivatives)

### DIFF
--- a/1.9/default.conf
+++ b/1.9/default.conf
@@ -21,8 +21,8 @@ server {
         location ~ ^/setup/index.php {
             fastcgi_pass   fastcgi_backend;
             fastcgi_index  index.php;
-            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
             include        fastcgi_params;
+            fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         }
     }
     
@@ -108,7 +108,7 @@ server {
         fastcgi_param  MAGE_MODE $MAGE_MODE;
     
         fastcgi_index  index.php;
-        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         include        fastcgi_params;
+        fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
     }
 }


### PR DESCRIPTION
The include statement should come first, and then the SCRIPT_FILENAME param can explicitly override the one from the include. I just spent an hour figuring out why my change had no effect. The reason was that the include was overriding my change...
