### PR TITLE
Support for https nginx rev proxy

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -2,6 +2,11 @@ upstream fastcgi_backend {
   server PHP_HOST:PHP_PORT;
 }
 
+map $http_x_forwarded_proto $fastcgi_https {
+  default '';
+  https on;
+}
+
 server {
   listen 80;
   server_name localhost;
@@ -25,6 +30,10 @@ server {
       fastcgi_pass   fastcgi_backend;
       fastcgi_index  index.php;
       fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+
+      fastcgi_param HTTPS $fastcgi_https;
+      fastcgi_param SERVER_PORT $http_x_forwarded_port;
+
       include    fastcgi_params;
     }
 
@@ -46,6 +55,10 @@ server {
       fastcgi_index  index.php;
       fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
       fastcgi_param  PATH_INFO    $fastcgi_path_info;
+
+      fastcgi_param HTTPS $fastcgi_https;
+      fastcgi_param SERVER_PORT $http_x_forwarded_port;
+
       include    fastcgi_params;
     }
 
@@ -165,6 +178,9 @@ server {
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
     fastcgi_param  MAGE_MODE $MAGE_MODE;
+
+    fastcgi_param HTTPS $fastcgi_https;
+    fastcgi_param SERVER_PORT $http_x_forwarded_port;
   
     fastcgi_index  index.php;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;


### PR DESCRIPTION
Support for https proxy, like `(client browser) -> (nginx revproxy on port :80 or :443) -> (docker backend on 127.0.0.1:8080)`, sample config:

``` nginx
upstream teststream {
  server 127.0.0.1:8080;
}

server {
    listen 80;
    server_name .teststream.dev;
    return 301 https://$host$request_uri;
}

server {
    listen 443 ssl;

    server_name .teststream.dev;

    root /dev/null;

    location / {
        # serve static files from defined root folder;.
        # @teststream is a named location for the upstream fallback, see below
        try_files $uri $uri/index.html $uri.html @teststream;
    }

    location @teststream {
        expires off;

        proxy_read_timeout 300;
        proxy_connect_timeout 300;
        #proxy_redirect     off;
        proxy_redirect     http:// $scheme://;

        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
        proxy_set_header   X-Forwarded-Proto $scheme;
        proxy_set_header   X-Forwarded-Port  $server_port;
        proxy_set_header   Host              $host;
        proxy_set_header   X-Real-IP         $remote_addr;

        proxy_pass http://teststream;
    }
}
```
