### PR TITLE
Removed X-XSS-Protection header (managed by m2 code)

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -16,7 +16,6 @@ server {
   charset off;
 
   add_header 'X-Content-Type-Options' 'nosniff';
-  add_header 'X-XSS-Protection' '1; mode=block';
 
   location /setup {
     root $MAGE_ROOT;


### PR DESCRIPTION
Closes https://github.com/mageinferno/docker-magento2-nginx/issues/12